### PR TITLE
Provide keyMirrorPrefix function as a default import 🌸

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For ES Modules:
 import { keyMirrorPrefix } from 'keymirrorprefix'
 ```
 
-The `keyMirrorPrefix` function can also be imported as a default export.
+The `keyMirrorPrefix` function is exported both as a default and named export, so you can import it either way.
 
 ### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Key Mirror Prefix is a utility for creating an object with values equal to its k
 - [Motivation](#motivation)
 - [Example](#example)
 - [Usage](#usage)
+  - [Installation](#installation)
+  - [Importing](#importing)
+  - [Example Usage](#example-usage)
 
 ## Motivation
 
@@ -49,6 +52,8 @@ This makes it clear whether the `SEARCH_SUCCESS` action came from `CITIES` or `C
 
 ## Usage
 
+### Installation
+
 First, install the package as a dependency:
 
 ```bash
@@ -59,7 +64,9 @@ yarn add keymirrorprefix
 npm install keymirrorprefix
 ```
 
-Then, you can import `keyMirrorPrefix` using either CommonJS or ES Modules:
+### Importing
+
+You can import `keyMirrorPrefix` using either CommonJS or ES Modules:
 
 For CommonJS:
 
@@ -72,6 +79,10 @@ For ES Modules:
 ```js
 import { keyMirrorPrefix } from 'keymirrorprefix'
 ```
+
+The `keyMirrorPrefix` function can also be imported as a default export.
+
+### Example Usage
 
 Once you've imported `keyMirrorPrefix`, you can use it to create an object with keys mirrored as values, prefixed with a specified string:
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/01taylop/key-mirror-prefix"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "./lib/index.js",
   "exports": {

--- a/src/index.js
+++ b/src/index.js
@@ -17,3 +17,5 @@ export {
   keyMirror,
   keyMirrorPrefix,
 }
+
+export default keyMirrorPrefix


### PR DESCRIPTION
## Details

### What have you changed?

- Made `keyMirrorPrefix` a default export as well as a named export.

### Why are you making these changes?

- To allow easier adoption of the new version.
